### PR TITLE
Update mFillPaint color on GradientDrawable inflation

### DIFF
--- a/graphics/java/android/graphics/drawable/GradientDrawable.java
+++ b/graphics/java/android/graphics/drawable/GradientDrawable.java
@@ -1019,6 +1019,7 @@ public class GradientDrawable extends Drawable {
         inflateChildElements(r, parser, attrs, theme);
 
         mGradientState.computeOpacity();
+        initializeWithState(mGradientState);
     }
 
     @Override


### PR DESCRIPTION
When a GradientDrawable is loaded from scratch, initializeWithState()
is called with mColors == null. This sets mFillPaint's color to
0x00000000 -- transparent. mColors is then properly set in inflate(),
but mFillPaint is not updated there. It will be updated eventually
through a mutate() or ensureValidRect() call, but that's sometimes too
late.

In our case, a wrapping StateListDrawable called getOpacity(), and
since it caches the result, it never got updated.

This doesn't cause any problems on preloaded GradientDrawables, since
the new GradientDrawable created when fetching a preload will call
initializeWithState() in its constructor, fixing the GradientState.

Change-Id: Ic8caa7c6a7c1d4dae5ff31ae943831bd2e014f79
