### PR TITLE
prevent unnecessary warning logs caused by View.toString()

### DIFF
--- a/core/java/android/view/View.java
+++ b/core/java/android/view/View.java
@@ -4300,7 +4300,7 @@ public class View implements Drawable.Callback, KeyEvent.Callback,
             out.append(" #");
             out.append(Integer.toHexString(id));
             final Resources r = mResources;
-            if (Resources.resourceHasPackage(id) && r != null) {
+            if (id > 0 && Resources.resourceHasPackage(id) && r != null) {
                 try {
                     String pkgname;
                     switch (id&0xff000000) {


### PR DESCRIPTION
If the id is negative, it is not from Resource.
Passing the negative value to getResourcePackageName makes AssetManager dump unnecessary warning logs.
It is reasonable not to get package/type/entry information for the negative id.

The warning logs :
W/ResourceType( 3711): No known package when getting name for resource
number 0x9b010100

Change-Id: Ic89acb4f32205ba5a2fdac61dc14b00ccf251148
