### PR TITLE
base: correct sensor handling

### DIFF
--- a/core/res/res/values/config.xml
+++ b/core/res/res/values/config.xml
@@ -2516,4 +2516,8 @@
     the NORMAL notification background to be dark and the text to be light, this boolean
     needs to be set to false, to prevent the doze notifications from being light -->
     <bool name="config_invert_colors_on_doze">true</bool>    
+
+    <!-- Older sensors are not setting event.timestamp correctly.  Setting to
+          true will use SystemClock.elapsedRealtimeNanos() to set timestamp-->
+    <bool name="config_useSystemClockforSensors">false</bool>
 </resources>

--- a/core/res/res/values/symbols.xml
+++ b/core/res/res/values/symbols.xml
@@ -2441,4 +2441,5 @@
   <!-- Config.xml entries -->
   <java-symbol type="bool" name="config_samsung_stk" />
 
+  <java-symbol type="bool" name="config_useSystemClockforSensors" />
 </resources>

--- a/services/core/java/com/android/server/policy/WindowOrientationListener.java
+++ b/services/core/java/com/android/server/policy/WindowOrientationListener.java
@@ -56,6 +56,7 @@ public abstract class WindowOrientationListener {
     private int mRate;
     private String mSensorType;
     private Sensor mSensor;
+    private boolean museSystemClockforSensors;
     private OrientationJudge mOrientationJudge;
     private int mCurrentRotation = -1;
 
@@ -105,9 +106,13 @@ public abstract class WindowOrientationListener {
             }
         }
 
+        museSystemClockforSensors = context.getResources().getBoolean(
+                com.android.internal.R.bool.config_useSystemClockforSensors);
+
         if (mOrientationJudge == null) {
             mSensor = mSensorManager.getDefaultSensor(USE_GRAVITY_SENSOR
                     ? Sensor.TYPE_GRAVITY : Sensor.TYPE_ACCELEROMETER);
+
             if (mSensor != null) {
                 // Create listener only if sensors do exist
                 mOrientationJudge = new AccelSensorJudge(context);
@@ -598,7 +603,12 @@ public abstract class WindowOrientationListener {
                 // Reset the orientation listener state if the samples are too far apart in time
                 // or when we see values of (0, 0, 0) which indicates that we polled the
                 // accelerometer too soon after turning it on and we don't have any data yet.
-                final long now = event.timestamp;
+                final long now;
+                if (museSystemClockforSensors) {
+                    now = SystemClock.elapsedRealtimeNanos();
+                } else {
+                    now = event.timestamp;
+                }
                 final long then = mLastFilteredTimestampNanos;
                 final float timeDeltaMS = (now - then) * 0.000001f;
                 final boolean skipSample;


### PR DESCRIPTION
Older sensors are not setting event.timestamp correctly.  Setting to
true will use SystemClock.elapsedRealtimeNanos() to set timestamp

Change-Id: I2adfb9974d14afd4a5feef790cf847470c55aa5d
Signed-off-by: Louis Popi theh2o64@gmail.com

Conflicts:
    core/res/res/values/config.xml
    core/res/res/values/symbols.xml
